### PR TITLE
Fix redstone connectivity for the pins of the MCU

### DIFF
--- a/src/main/java/com/elmfer/cnmcu/blockentities/CNnanoBlockEntity.java
+++ b/src/main/java/com/elmfer/cnmcu/blockentities/CNnanoBlockEntity.java
@@ -50,8 +50,11 @@ public class CNnanoBlockEntity extends BlockEntity implements ExtendedScreenHand
         int i = 0;
         for (Direction horizontal : HORIZONTALS) {
             Direction globalDir = CNnanoBlock.getGlobalDirection(blockDir, horizontal);
-            inputs[i] = world.getStrongRedstonePower(pos.offset(globalDir), globalDir.getOpposite());
-            inputs[i++] |= world.getEmittedRedstonePower(pos.offset(globalDir), globalDir.getOpposite());
+            BlockPos neighborPos = pos.offset(globalDir);
+            BlockState neighborState = world.getBlockState(neighborPos);
+            
+            inputs[i] = neighborState.getWeakRedstonePower(world, neighborPos, globalDir);
+            inputs[i++] |= world.getEmittedRedstonePower(neighborPos, globalDir);
         }
         
         blockEntity.mcu.frontInput = inputs[0];


### PR DESCRIPTION
Previously, MCU cannot pick up signals from angled redstone wires, or any type of gate (like repeaters) placed right next to it